### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ion-alpha-scroll
 
 > Configurable Ionic directive for alphabetically indexed list with an alpha scroll bar.
 
-#Table of contents
+# Table of contents
 
 - [Demo](#demo)
 - [Installation](#installation)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
